### PR TITLE
Remove unimplemented OTP application callback module from app.src.

### DIFF
--- a/src/quantile_estimator.app.src
+++ b/src/quantile_estimator.app.src
@@ -7,6 +7,5 @@
                   kernel,
                   stdlib
                  ]},
-  {mod, { annalist_app, []}},
   {env, []}
  ]}.


### PR DESCRIPTION
It seems that at one time, the intention was to create an OTP application callback module named `annalist_app`.  However, this module was never created and does not exist.

The `quantile_estimator` library doesn't need any application `start`/`stop` functionality in its current form, so it counts as a library application.  To make it work as a library application in OTP releases, we can simply remove the `mod` keyword from the `app.src`.

This PR does this, and as a result, this library is now usable from another OTP application's release.
