### PR TITLE
Remove ambiguous ceil and floor functions, replace random with rand

### DIFF
--- a/src/quantile.erl
+++ b/src/quantile.erl
@@ -3,7 +3,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--export([ceil/1]).
 -define(DEBUG, true).
 -endif.
 
@@ -54,16 +53,6 @@ ranks(Size, Quantile) ->
 			[ceil(Size * Quantile)]
 	end.
 
--spec ceil(float()) -> integer().
-ceil(X) ->
-    T = erlang:trunc(X),
-    case (X - T) of
-        Neg when Neg < 0 -> T;
-        Pos when Pos > 0 -> T + 1;
-        _ -> T
-    end.
-
-
 % TESTS
 rank_average(Size, Quantile) ->
 	case ranks(Size, Quantile) of
@@ -81,8 +70,7 @@ quantile_test_() ->
 	fun test_setup/0,
 	fun test_teardown/1,
 	[
-		{"test ceil", fun  ceil_test/0}
-		,{"test ranks", fun ranks_test/0}
+		{"test ranks", fun ranks_test/0}
 		,{"test natural", fun natural_test/0}
 		,{"test even", fun even_test/0}
 		,{"test quantiles", fun quantile_test/0}
@@ -114,13 +102,6 @@ even_test() ->
 	,?assertEqual(true, even(-10))
 	,?assertEqual(false, even(11))
 	,?assertEqual(false, even(-11)).
-
-ceil_test() ->
-	?assertEqual(1, ceil(1.0))
-	,?assertEqual(2, ceil(1.1))
-	,?assertEqual(2, ceil(1.8))
-	,?assertEqual(-1, ceil(-1.8))
-	,?assertEqual(-1, ceil(-1.1)).
 
 quantile_test() ->
 	Samples1 = [3.0, 6.0, 7.0, 8.0, 8.0, 10.0, 13.0, 15.0, 16.0, 20.0]

--- a/src/quantile_estimator.erl
+++ b/src/quantile_estimator.erl
@@ -160,14 +160,6 @@ quantile(Phi, Invariant, [Next = #group{g = Gi, delta = Deltai}|DataStructure], 
 			quantile(Phi, Invariant, DataStructure, N, Rank + Gi, Next)
 	end.
 
-floor(X) ->
-    T = erlang:trunc(X),
-    case (X - T) of
-        Neg when Neg < 0 -> T - 1;
-        Pos when Pos > 0 -> T;
-        _ -> T
-    end.
-
 clamp(X) when X >= 0 -> X;
 clamp(X) when X < 0 -> 0.
 
@@ -273,7 +265,7 @@ test_quantile() ->
 	% we create a set of 1000 random values and test if the guarantees are met
 	Invariant = f_biased(0.001),
 	N = 1000,
-	Samples = [random:uniform()||_ <- lists:seq(1, N)],
+	Samples = [rand:uniform()||_ <- lists:seq(1, N)],
 	Data = lists:foldl(fun(Sample, Stats) -> insert(Sample, Stats) end, quantile_estimator:new(Invariant), Samples),
 	% error_logger:info_msg("D:~p\n", [D]),
 	validate(Samples, Invariant, Data),
@@ -288,7 +280,7 @@ test_compression_biased() ->
 	% we create a set of 1000 random values and test if the guarantees are met
 	Invariant = f_biased(0.01),
 	N = 2000,
-	Samples = [random:uniform()||_ <- lists:seq(1, N)],
+	Samples = [rand:uniform()||_ <- lists:seq(1, N)],
 	Data = lists:foldl(fun(Sample, Stats) -> insert(Sample, Stats) end, quantile_estimator:new(Invariant), Samples),
 	DL = Data#quantile_estimator.data,
 	validate(Samples, Invariant, Data),
@@ -298,7 +290,7 @@ test_comression_targeted() ->
 	% we create a set of 1000 random values and test if the guarantees are met
 	Invariant = quantile_estimator:f_targeted([{0.05, 0.005}, {0.5, 0.02}, {0.95, 0.005}]),
 	N = 2000,
-	Samples = [random:uniform()||_ <- lists:seq(1, N)],
+	Samples = [rand:uniform()||_ <- lists:seq(1, N)],
 	Data = lists:foldl(fun(Sample, Stats) -> insert(Sample, Stats) end, quantile_estimator:new(Invariant), Samples),
 	DL = Data#quantile_estimator.data,
 	validate(Samples, Invariant, Data),
@@ -339,7 +331,7 @@ validate(Samples, Invariant, Estimate = #quantile_estimator{samples_count = N, d
 			Index(quantile:quantile(Q, SamplesSort), SamplesSort), 
 			Index(quantile(Q, Estimate), SamplesSort), 
 			abs(Index(quantile:quantile(Q, SamplesSort), SamplesSort) - Index(quantile(Q, Estimate), SamplesSort)),
-			quantile:ceil(Invariant(Index(quantile(Q, Estimate), SamplesSort), N))
+			ceil(Invariant(Index(quantile(Q, Estimate), SamplesSort), N))
 		} || Q <- Quantiles],
 	% [error_logger:info_msg("QReal:~p,~p,~p\n", [Q, N, quantile:quantile(Q, SamplesSort)]) || Q <- [0.0, 1.0]],
 	% [error_logger:info_msg("QEst:~p,~p,~p\n", [Q, N, quantile(Q, Invariant, Estimate)]) || Q <- [0.0, 1.0]],


### PR DESCRIPTION
Fix ceil and floor functions. This functions were added in OTP-18, so there is no need to implement them. Also replace random with rand to keep code more up to date.