### PR TITLE
make calls to ceil and floor unambigous

### DIFF
--- a/src/quantile.erl
+++ b/src/quantile.erl
@@ -13,6 +13,8 @@
 -export([quantile/2]).
 -export([rank_average/2]).
 
+-compile({no_auto_import,[ceil/1]}).
+
 -spec quantile(float(), samples()) -> sample().
 quantile(0.0, [First|_]) ->
 	First;

--- a/src/quantile_estimator.erl
+++ b/src/quantile_estimator.erl
@@ -18,6 +18,8 @@
 	f_targeted/1
 ]).
 
+-compile({no_auto_import,[floor/1]}).
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -define(DEBUG, true).


### PR DESCRIPTION
Just something to make these warnings go away

```
_build/default/lib/quantile_estimator/src/quantile.erl:54:5: Warning: ambiguous call of overridden auto-imported BIF ceil/1
 - use erlang:ceil/1 or "-compile({no_auto_import,[ceil/1]})." to resolve name clash

_build/default/lib/quantile_estimator/src/quantile_estimator.erl:97:49: Warning: ambiguous call of overridden auto-imported BIF floor/1
 - use erlang:floor/1 or "-compile({no_auto_import,[floor/1]})." to resolve name clash
```