### PR TITLE
quantile: fix handling of -0.0 for OTP-26.1/27.0

### DIFF
--- a/src/quantile.erl
+++ b/src/quantile.erl
@@ -14,7 +14,7 @@
 -export([rank_average/2]).
 
 -spec quantile(float(), samples()) -> sample().
-quantile(0.0, [First|_]) ->
+quantile(Num, [First|_]) when Num == 0.0 ->
 	First;
 
 quantile(1.0, Samples) ->


### PR DESCRIPTION
Matching of floating-point zeroes will change in OTP-27 so that -0.0 will no longer match a non-negative 0.0. OTP-26.1 warns about such constructs, which in quantile_estimator results in:

===> Compiling quantile_estimator
src/quantile.erl:17:10: Warning: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.

Fixed by switching from a match to a numerical comparison.